### PR TITLE
Frontend 로그인 로직 추가

### DIFF
--- a/frontend/.babelrc.js
+++ b/frontend/.babelrc.js
@@ -4,5 +4,3 @@ module.exports = {
   presets: ["next/babel", "@zeit/next-typescript/babel"],
   plugins: [["transform-define", env], ["styled-components", { ssr: true, displayName: true, preprocess: false }]]
 };
-
-// { ssr: true, displayName: true, preprocess: false }

--- a/frontend/lib/client/queries.js
+++ b/frontend/lib/client/queries.js
@@ -6,3 +6,9 @@ export const GET_ISLOGIN = gql`
     isLogin @client
   }
 `;
+
+export const SET_ISLOGIN = gql`
+  mutation SetIsLogin($isLogin: Boolean) {
+    setIsLogin(isLogin: $isLogin) @client
+  }
+`;

--- a/frontend/lib/withApollo.js
+++ b/frontend/lib/withApollo.js
@@ -9,16 +9,18 @@ const parseCookies = (req, options = {}) => cookie.parse(req ? req.headers.cooki
 
 export default App =>
   class WithData extends React.Component {
-    static async getInitialProps({ ctx, router, Component }) {
+    static async getInitialProps({ Component, router, ctx }) {
       const props = {};
+
+      const token = parseCookies(ctx.req).token;
+      ctx.token = token;
+
+      const apolloClient = initApollo({}, token);
+      ctx.apolloClient = apolloClient;
 
       if (Component.getInitialProps) props.pageProps = await Component.getInitialProps(ctx);
 
-      const token = parseCookies(ctx.req).token;
-      props.token = token;
-
       if (ctx.req) {
-        const apolloClient = initApollo({}, token);
         try {
           await getDataFromTree(
             <WithData {...props} apolloClient={apolloClient} router={router} Component={Component} />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "yarn tslint -e './**/*.js?(x)' --project ."
   },
   "dependencies": {
+    "@types/cookie": "^0.3.2",
     "@zeit/next-typescript": "^1.1.1",
     "apollo-cache-inmemory": "^1.4.2",
     "apollo-client": "^2.4.12",

--- a/frontend/pages/login/LoginContainer.tsx
+++ b/frontend/pages/login/LoginContainer.tsx
@@ -1,22 +1,41 @@
+import cookie from "cookie";
 import { NextContext } from "next";
+import Router from "next/router";
 import React from "react";
 import { withApollo } from "react-apollo";
+import { SET_ISLOGIN } from "../../lib/client/queries";
+import checkLogin from "../../utils/checkLogin";
 import LoginPresenter from "./LoginPresenter";
 import { EMAIL_SIGN_IN } from "./LoginQueries";
+import redirect from "../../utils/redirect";
 
 interface IProps {
   from: string;
+  // loggedInUser: {
+  //   ok: boolean;
+  //   error: string;
+  // };
 }
 
 class Login extends React.Component<IProps> {
-  static async getInitialProps({ req }: NextContext): Promise<IProps> {
+  static async getInitialProps(context: NextContext): Promise<IProps> {
     const initialProps = {
       from: "client"
     };
 
-    if (req) {
+    const { loggedInUser } = await checkLogin(context.apolloClient);
+
+    if (context.req) {
       // server side
       initialProps.from = "server";
+      if (loggedInUser) {
+        redirect(context, "/");
+      }
+    } else {
+      // redirect if logged in && client side
+      if (loggedInUser) {
+        redirect({}, "/");
+      }
     }
 
     return initialProps;
@@ -29,18 +48,33 @@ class Login extends React.Component<IProps> {
     this.setState({
       [e.target.name]: e.target.value
     });
-  _handleSubmit = () => {
+  _handleSubmit = async () => {
     const { email, password } = this.state;
-    this.props.client
-      .mutate({
-        mutation: EMAIL_SIGN_IN,
-        variables: {
-          email,
-          password
-        }
-      })
-      .then(res => console.log(res))
-      .catch(err => console.log(err));
+    const { data } = await this.props.client.mutate({
+      mutation: EMAIL_SIGN_IN,
+      variables: {
+        email,
+        password
+      }
+    });
+    if (data.EmailSignIn.ok) {
+      document.cookie = cookie.serialize("token", data.EmailSignIn.token, {
+        maxAge: 30 * 24 * 60 * 60 // 30 days
+      });
+
+      this.props.client.cache.reset().then(() =>
+        this.props.client
+          .mutate({
+            mutation: SET_ISLOGIN,
+            variables: { isLogin: true }
+          })
+          .then(() => {
+            Router.replace("/");
+          })
+      );
+    } else {
+      console.log(data.EmailSignIn.error);
+    }
   };
   render() {
     return (

--- a/frontend/pages/login/LoginPresenter.tsx
+++ b/frontend/pages/login/LoginPresenter.tsx
@@ -3,13 +3,14 @@ import styled from "styled-components";
 
 interface IProps {
   from: string;
+  loggedInUser: any;
   email: string;
   password: string;
   handleChange: (e: any) => void;
   handleSubmit: () => void;
 }
 
-export default ({ from, email, password, handleChange, handleSubmit }: IProps) => (
+export default ({ from, loggedInUser, email, password, handleChange, handleSubmit }: IProps) => (
   <Container>
     <h1>Login page</h1>
     <p>Rendered from {from}</p>

--- a/frontend/utils/checkLogin.js
+++ b/frontend/utils/checkLogin.js
@@ -1,0 +1,32 @@
+import gql from "graphql-tag";
+
+export const ME = gql`
+  query {
+    GetMyProfile {
+      ok
+      profile {
+        id
+        email
+        firstName
+        lastName
+        fullName
+        createdAt
+        updatedAt
+      }
+      error
+    }
+  }
+`;
+
+export default apolloClient =>
+  apolloClient
+    .query({
+      query: ME
+    })
+    .then(({ data: { GetMyProfile } }) => {
+      return { loggedInUser: GetMyProfile };
+    })
+    .catch(() => {
+      // Fail gracefully
+      return { loggedInUser: null };
+    });

--- a/frontend/utils/redirect.js
+++ b/frontend/utils/redirect.js
@@ -1,0 +1,11 @@
+import Router from "next/router";
+
+export default (context, target) => {
+  if (context.res) {
+    // server
+    context.res.writeHead(303, { Location: target });
+    context.res.end();
+  } else {
+    Router.replace(target);
+  }
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -753,6 +753,11 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.0.tgz#d1d55958d1fccc5527d4aba29fc9c4b942f563ff"
   integrity sha512-7WcbyctkE8GTzogDb0ulRAEw7v8oIS54ft9mQTU7PfM0hp5e+8kpa+HeQ7IQrFbKtJXBKcZ4bh+Em9dTw5L6AQ==
 
+"@types/cookie@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.2.tgz#453f4b14b25da6a8ea4494842dedcbf0151deef9"
+  integrity sha512-aHQA072E10/8iUQsPH7mQU/KUyQBZAGzTVRCUvnSz8mSvbrYsP4xEO2RSA0Pjltolzi0j8+8ixrm//Hr4umPzw==
+
 "@types/next-server@*":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@types/next-server/-/next-server-7.0.2.tgz#7115f4f9ad9605d4ce1d36b0e125dd523670c7b4"


### PR DESCRIPTION
(목적) Frontend에 구현한 Apollo 로직 테스트를 위해 로그인 추가 구현 및 테스트

1. 기존 Apollo-client 로직 일부 수정

2. login page 추가
- 우선 로직 구현 및 테스트를 위해 IProps 등 types 설정은 추후 업데이트 필요.

3. 향후 Frontend 개발 시 로그인 유무 구분 시 `/frontend/pages/login/LoginContainer.tsx`의 checkLogin 모듈 참고 하시면 좋을 것 같습니다.