### PR TITLE
hotfix/lint - tslint[ignore-bound-class-methods]

### DIFF
--- a/backend/tslint.json
+++ b/backend/tslint.json
@@ -26,7 +26,8 @@
     "no-empty": false,
     "no-var-requires": false,
     "no-namespace": [true, "allow-declarations"],
-    "arrow-parens": [true, "ban-single-arg-parens"]
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "semicolon": [true, "always", "ignore-bound-class-methods"]
   },
   "linterOptions": {
     "exclude": ["node_modules"]

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -26,7 +26,8 @@
     "no-empty": false,
     "no-var-requires": false,
     "no-namespace": [true, "allow-declarations"],
-    "arrow-parens": [true, "ban-single-arg-parens"]
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "semicolon": [true, "always", "ignore-bound-class-methods"]
   },
   "linterOptions": {
     "exclude": ["node_modules"]


### PR DESCRIPTION
tslint.json 수정

class 내에 method에 대해 세미콜론 찍어도 무시하는 걸로 수정 (prettier는 세미콜론 찍음;;)